### PR TITLE
Backport export_apply to main.

### DIFF
--- a/addons/blend/import_blend.gd
+++ b/addons/blend/import_blend.gd
@@ -67,19 +67,20 @@ func _import_scene(path: String, flags: int, bake_fps: int):
 	var stdout = [].duplicate()
 	var addon_path : String = blender_path
 	var addon_path_global = ProjectSettings.globalize_path(addon_path)
-	var script : String = ("import bpy, os, sys;" +
-		"bpy.ops.wm.open_mainfile(filepath='GODOT_FILENAME');" +
-		"bpy.ops.export_scene.gltf(filepath='GODOT_EXPORT_PATH',export_format='GLB',export_colors=True,export_all_influences=True,export_extras=True,export_cameras=True,export_lights=True,export_apply=(len(bpy.data.shape_keys)==0));")
+	var params: PoolStringArray = [
+		"filepath='%s'" % output_path_global,
+		"export_format='GLB'",
+		"export_colors=True",
+		"export_all_influences=True",
+		"export_extras=True",
+		"export_cameras=True",
+		"export_lights=True",
+		"export_apply=(len(bpy.data.shape_keys)==0)"
+	]
+	var script : String = "import bpy; bpy.ops.export_scene.gltf(%s)" % params.join(",")
 	path_global = path_global.c_escape()
-	script = script.replace("GODOT_FILENAME", path_global)
-	output_path_global = output_path_global.c_escape()
-	script = script.replace("GODOT_EXPORT_PATH", output_path_global)
-	var dir = Directory.new()
-	var tex_dir_global = output_path_global + "_textures"
-	tex_dir_global.c_escape()
-	dir.make_dir(tex_dir_global)
-	script = script.replace("GODOT_TEXTURE_PATH", tex_dir_global)
 	var args = [
+		path_global,
 		"--background",
 		"--python-expr",
 		script]

--- a/addons/blend/import_blend.gd
+++ b/addons/blend/import_blend.gd
@@ -65,8 +65,9 @@ func _import_scene(path: String, flags: int, bake_fps: int):
 	var output_path_global = ProjectSettings.globalize_path(output_path)
 	output_path_global = output_path_global.c_escape()
 	var stdout = [].duplicate()
+	var addon_path : String = blender_path
 	var addon_path_global = ProjectSettings.globalize_path(addon_path)
-	var params: PoolStringArray = [
+	var params: PackedStringArray = [
 		"filepath='%s'" % output_path_global,
 		"export_format='GLB'",
 		"export_colors=True",
@@ -76,24 +77,24 @@ func _import_scene(path: String, flags: int, bake_fps: int):
 		"export_lights=True",
 		"export_apply=(len(bpy.data.shape_keys)==0)"
 	]
-	var script : String = "import bpy; bpy.ops.export_scene.gltf(%s)" % params.join(",")
+	var script : String = "import bpy; bpy.ops.export_scene.gltf(%s)" % ",".join(params)
 	path_global = path_global.c_escape()
-	var args = PoolStringArray([
+	var args = PackedStringArray([
 		path_global,
 		"--background",
 		"--python-expr",
 		script
 	])
-	var ret = OS.execute(addon_path_global, args, true, stdout, true)
+	var ret = OS.execute(addon_path_global, args, stdout, true)
 	if ret != OK:
 		push_error(
 			"Blender import failed with code=%d.\nCommand: %s\nOutput: %s" % [
 				ret,
-				args.join(" "),
-				PoolStringArray(stdout).join("\n")
+				" ".join(args),
+				"\n".join(stdout)
 			]
 		)
 		return null
 	var gltf_importer : EditorSceneFormatImporterGLTF = EditorSceneFormatImporterGLTF.new()
-	var root_node: Node3D = gltf_importer._import_scene_from_other_importer(output_path, flags, bake_fps)
+	var root_node: Node3D = gltf_importer.import_scene_from_other_importer(output_path, flags, bake_fps)
 	return root_node

--- a/addons/blend/import_blend.gd
+++ b/addons/blend/import_blend.gd
@@ -69,7 +69,7 @@ func _import_scene(path: String, flags: int, bake_fps: int):
 	var addon_path_global = ProjectSettings.globalize_path(addon_path)
 	var script : String = ("import bpy, os, sys;" +
 		"bpy.ops.wm.open_mainfile(filepath='GODOT_FILENAME');" +
-		"bpy.ops.export_scene.gltf(filepath='GODOT_EXPORT_PATH',export_format='GLB',export_colors=True,export_all_influences=True,export_extras=True,export_cameras=True,export_lights=True);")
+		"bpy.ops.export_scene.gltf(filepath='GODOT_EXPORT_PATH',export_format='GLB',export_colors=True,export_all_influences=True,export_extras=True,export_cameras=True,export_lights=True,export_apply=(len(bpy.data.shape_keys)==0));")
 	path_global = path_global.c_escape()
 	script = script.replace("GODOT_FILENAME", path_global)
 	output_path_global = output_path_global.c_escape()


### PR DESCRIPTION
- Apply modifiers if no shape keys exist.
- Clean up code.
- Reduce verbosity, only print on error.
- Adjust for godot 4.

Backport of #5.
