### PR TITLE
Avoid error on first opening.

### DIFF
--- a/addons/blend/import_blend.gd
+++ b/addons/blend/import_blend.gd
@@ -29,9 +29,8 @@ var blender_path : String
 
 func _init():
 	if not ProjectSettings.has_setting(settings_blender_path):
-		ProjectSettings.set_initial_value(settings_blender_path, "blender")
 		ProjectSettings.set_setting(settings_blender_path, "blender")
-
+		ProjectSettings.set_initial_value(settings_blender_path, "blender")
 	else:
 		blender_path = ProjectSettings.get_setting(settings_blender_path)
 	var property_info = {


### PR DESCRIPTION
The first time you load this plugin, it will always print an error:

```
ERROR: Request for nonexistent project setting: filesystem/import/blend/blender_path.
```

It seems that `set_setting` must be called before `set_initial_value`,
as the latter expect the setting to already exist.

See: https://github.com/godotengine/godot/blob/406e26abeb31f76a401762e82d5640f5d73e7902/core/config/project_settings.cpp#L199
